### PR TITLE
1: fix PM-to-AM coercion for values between 12-1PM

### DIFF
--- a/src/modules/Calendar/useCalendar.ts
+++ b/src/modules/Calendar/useCalendar.ts
@@ -49,7 +49,6 @@ export function useCalendar() {
     hour = hour % 12
     if (hour === 0) {
       hour = 12
-      hourStr = 'AM'
     }
     let minuteStr = minute.toString().padStart(2, '0')
 


### PR DESCRIPTION
**sui-calendar**: when updating the time to "12:45 PM", it automatically gets overwritten to "12:45 AM". Happens for any time between 12:00 - 12:59 PM. You can reproduce this yourself on [this page](https://nightswinger.github.io/vue-fomantic-ui/modules/calendar)

The cause is the redundant line removed in this PR.