### PR TITLE
Support `Icon` Option in `SelectionDropdown` Options

### DIFF
--- a/docs/src/components/modules/Dropdown/SelectionIconDoc.vue
+++ b/docs/src/components/modules/Dropdown/SelectionIconDoc.vue
@@ -1,0 +1,68 @@
+<template>
+  <DocSection label="Selection Icon" :code="code">
+    <template #description>
+      A selection icon dropdown can be used to select between choices in a form,
+      with an icon on the left. Icon list is available at
+      <a
+        href="https://fomantic-ui.com/elements/icon.html"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        the Fomantic UI website
+      </a>
+    </template>
+    <template #example>
+      <Dropdown
+        v-model="selected"
+        :options="options"
+        selection
+        fluid
+        placeholder="Social Media"
+      />
+    </template>
+  </DocSection>
+</template>
+
+<script setup lang="ts">
+import DocSection from '@/components/doc/DocSection.vue'
+
+import { ref } from 'vue'
+import { Dropdown } from 'vue-fomantic-ui'
+
+const selected = ref()
+const options = [
+  { icon: 'instagram', text: 'Instagram' },
+  { icon: 'facebook f', text: 'Facebook' },
+  { icon: 'reddit', text: 'Reddit' },
+  { icon: 'tiktok', text: 'Tiktok' },
+  { icon: 'twitter', text: 'Twitter' },
+  { icon: 'twitch', text: 'Twitch' },
+  { icon: 'weibo', text: 'Weibo' }
+]
+
+const code = `<template>
+  <Dropdown
+    v-model="selected"
+    :options="options"
+    selection
+    fluid
+    placeholder="Social Media"
+  />
+<\/template>
+
+<script setup>
+import { ref } from 'vue'
+import { Dropdown } from 'vue-fomantic-ui'
+
+const selected = ref()
+const options = [
+  { icon: 'instagram', text: 'Instagram' },
+  { icon: 'facebook f', text: 'Facebook' },
+  { icon: 'reddit', text: 'Reddit' },
+  { icon: 'tiktok', text: 'Tiktok' },
+  { icon: 'twitter', text: 'Twitter' },
+  { icon: 'twitch', text: 'Twitch' },
+  { icon: 'weibo', text: 'Weibo' },
+]
+<\/script>`
+</script>

--- a/docs/src/pages/modules/Dropdown.vue
+++ b/docs/src/pages/modules/Dropdown.vue
@@ -12,6 +12,7 @@ import DocComponent from '@/components/doc/DocComponent.vue'
 // Types
 import DropdownDoc from '@/components/modules/Dropdown/DropdownDoc.vue'
 import SelectionDoc from '@/components/modules/Dropdown/SelectionDoc.vue'
+import SelectionIconDoc from '@/components/modules/Dropdown/SelectionIconDoc.vue'
 import SearchSelectionDoc from '@/components/modules/Dropdown/SearchSelectionDoc.vue'
 import ClearableSelectionDoc from '@/components/modules/Dropdown/ClearableSelectionDoc.vue'
 import MultipleSelectionDoc from '@/components/modules/Dropdown/MultipleSelectionDoc.vue'
@@ -41,6 +42,12 @@ const docs = [
     label: 'Selection',
     category: 'Types',
     component: SelectionDoc,
+  },
+  {
+    id: 'selection-icon',
+    label: 'Selection Icon',
+    category: 'Types',
+    component: SelectionIconDoc,
   },
   {
     id: 'search-selection',

--- a/src/components/Select/Input.tsx
+++ b/src/components/Select/Input.tsx
@@ -2,7 +2,7 @@ import { computed, defineComponent, ref, watch, withModifiers } from 'vue'
 import clsx from 'clsx'
 
 import LabelGroup from './LabelGroup'
-
+import Icon from '../Icon/Icon'
 import Image from '../Image/Image'
 
 import type { PropType } from 'vue'
@@ -112,6 +112,7 @@ export default defineComponent({
             !Array.isArray(props.value) &&
             typeof props.value === 'object' &&
             <>
+              {props.value?.icon && <Icon name={props.value.icon} />}
               {props.value?.flag && <i class={`${props.value.flag} flag`} />}
               {props.value?.image && <Image {...props.value.image} />}
               {props.value?.text}

--- a/src/components/Select/Item.tsx
+++ b/src/components/Select/Item.tsx
@@ -2,6 +2,7 @@ import { computed, defineComponent } from 'vue'
 
 import type { PropType } from 'vue'
 
+import Icon from '../Icon/Icon'
 import Image from '../Image/Image'
 
 export type OptionItem = string | {
@@ -9,6 +10,7 @@ export type OptionItem = string | {
   value: string | number;
   flag?: string;
   image?: { avatar?: boolean; src?: string };
+  icon?: string;
 }
 
 export default defineComponent({
@@ -28,6 +30,7 @@ export default defineComponent({
 
     const flag = computed(() => typeof props.option === 'object' ? props.option?.flag : undefined)
     const image = computed(() => typeof props.option === 'object' ? props.option?.image : undefined)
+    const icon = computed(() => typeof props.option === 'object' ? props.option?.icon : undefined)
 
     return () => (
       <div
@@ -35,6 +38,7 @@ export default defineComponent({
         data-value={value.value}
         onClick={() => emit('select', props.option)}
       >
+        {icon.value && <Icon name={icon.value} />}
         {flag.value && <i class={`${flag.value} flag`} />}
         {image.value && <Image {...image.value} />}
         {text.value}


### PR DESCRIPTION
## Introduction

Good evening!

First off, let me begin by saying a huge thanks and お疲れ様です for creating and developing this library! We had a number of components that are still using Vue 2 and Semantic UI. We wanted to migrate them to Vue 3 in order to make use of the new features and the ease of maintenance. Sadly, https://github.com/Semantic-UI-Vue/Semantic-UI-Vue only supports Vue 2, so I decided to research possible alternatives and stumbled upon https://github.com/fomantic/Fomantic-UI and in extension, this library.

It's been very helpful for us to migrate to Vue 3 while still preserving the same components 🎉 

## Description

We have a component which was using an icon in the `SelectionDropdown` component. I noticed [that in Semantic UI Vue, adding icons to a `SelectionDropdown` is supported](https://github.com/Semantic-UI-Vue/Semantic-UI-Vue/blob/afc18c60987257a41df5bdca202488215a19228c/src/modules/Dropdown/Dropdown.jsx#L310), but in this library, it seems that we do not support it.

This PR aims to support that: a `SelectionDropdown` with an icon at the left of the item.

Also, I added an example in the Storybook about how to use this component and where to get the icons, as I believe having such instructions will be helpful for anyone who wishes to use this library.

It would be nice if we can get this released so everyone can use it!

## Screenshot

I tested the changes by manually building the library and adjusting the import paths in the Storybook, and it works as I expected.

<img width="1016" alt="Screenshot 2024-06-24 at 22 09 03" src="https://github.com/nightswinger/vue-fomantic-ui/assets/31909304/0bb11ce1-0678-4bc1-b1bc-652efaa86759">

## Closing

Thank you very much! Please don't hesitate to let me know if there's any changes or adjustments that I need to make.