### PR TITLE
Fix `types` declaration in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   ],
   "main": "./dist/vue-fomantic-ui.umd.cjs",
   "module": "./dist/vue-fomantic-ui.js",
-  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/vue-fomantic-ui.js",
       "require": "./dist/vue-fomantic-ui.umd.cjs"
     }


### PR DESCRIPTION
Fixes the `types` declaration so that it's located in `exports` instead of a standalone property. This should fix the TypeScript error that I mentioned in the issue.

Thank you!

Resolves #81.